### PR TITLE
switch to jemalloc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,10 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y postgresql-client && \
+    apt-get install --no-install-recommends -y postgresql-client libjemalloc2 && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 # Run and own the application files as a non-root user for security
 RUN useradd rails --home /rails --shell /bin/bash


### PR DESCRIPTION
Pre-jemalloc, we went to 530 megabytes after serving all early morning requests (export for rating.chgk.info):

![Screenshot 2024-03-02 at 13 45 01](https://github.com/maii-chgk/rating-ui/assets/2369296/c25f7c73-0d43-448c-8d16-3861f3a79f5a)


With jemalloc, we peak at 455 and go down to 400:

![Screenshot 2024-03-02 at 13 46 16](https://github.com/maii-chgk/rating-ui/assets/2369296/b4373f05-7dd3-4e32-a04f-82a951589ffb)

jemalloc is supposed to be better at dealing with fragmentation and specifically situations where we allocate (and release) a lot of objects in a short period of time.

See also https://bugs.ruby-lang.org/issues/9113#note-13
