### PR TITLE
enable :en locale to fix dates in mission control

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module RatingUi
     # config.eager_load_paths << Rails.root.join("extras")
     config.action_controller.default_url_options = {trailing_slash: true}
 
-    config.i18n.available_locales = :ru
+    config.i18n.available_locales = [:en, :ru]
     config.i18n.default_locale = :ru
     # Don't generate system test files.
     config.generators.system_tests = nil


### PR DESCRIPTION
Otherwise, i18n can’t find translation for date-related words, and Mission Control’s dashboard can’t tell when a job was enqueued or finished.

![Screenshot 2025-03-16 at 18 48 20](https://github.com/user-attachments/assets/1227493d-f3ee-43ae-a84e-b76041232a66)
