### PR TITLE
add explicit wait in release page tests

### DIFF
--- a/test/system/team_release_page_test.rb
+++ b/test/system/team_release_page_test.rb
@@ -4,7 +4,7 @@ require "minitest/autorun"
 class TeamReleasePageTest < ActionDispatch::IntegrationTest
   def assert_row_has_correct_team(row, expected_place, expected_team, expected_city, expected_rating)
     place, team, city, rating = row
-    assert_equal place, expected_place
+    assert_equal place, expected_place, wait: 5
     assert_equal team, expected_team
     assert_equal city, expected_city
     assert_equal rating, expected_rating


### PR DESCRIPTION
This test was flaky in CI, but waiting for data in a row to appear fixes the problem. We are doing this in assert_row_has_correct_team (and before, so seemingly unnecessarily multiple times) since we need to wait for data, not for headers.

80 reruns in CI: https://github.com/chgk-gg/rating-ui/actions/runs/14145848131