### PR TITLE
run truedl job as many per-tournament jobs

### DIFF
--- a/app/jobs/truedl_for_all_tournaments_job.rb
+++ b/app/jobs/truedl_for_all_tournaments_job.rb
@@ -4,6 +4,17 @@ class TrueDLForAllTournamentsJob < ApplicationJob
   queue_as :default
 
   def perform(model_name)
-    TrueDLCalculator.calculate_for_all_tournaments_since_2021(model_name:)
+    model = Model.find_by(name: model_name)
+    unless model
+      Rails.logger.error "no model with the name #{model_name}"
+      return
+    end
+
+    tournaments = Tournament.where("start_datetime >= '2021-09-01'").pluck(:id)
+    single_tournament_jobs = tournaments.map do |tournament_id|
+      TrueDLForTournamentJob.new(model_name, tournament_id)
+    end
+
+    ActiveJob.perform_all_later(single_tournament_jobs)
   end
 end

--- a/app/jobs/truedl_for_tournament_job.rb
+++ b/app/jobs/truedl_for_tournament_job.rb
@@ -1,0 +1,9 @@
+require_relative "../lib/truedl_calculator"
+
+class TrueDLForTournamentJob < ApplicationJob
+  queue_as :default
+
+  def perform(model_name, tournament_id)
+    TrueDLCalculator.calculate_for_tournament(tournament_id:, model_name:)
+  end
+end

--- a/app/lib/truedl_calculator.rb
+++ b/app/lib/truedl_calculator.rb
@@ -15,22 +15,6 @@ class TrueDLCalculator
     TrueDLCalculator.new(tournament_id, model_name).run
   end
 
-  def self.calculate_for_all_tournaments_since_2021(model_name:)
-    model = Model.find_by(name: model_name)
-    unless model
-      Rails.logger.error "no model with the name #{model_name}"
-      return
-    end
-
-    tournaments = Tournament.where("start_datetime >= '2021-09-01'").pluck(:id)
-    Rails.logger.info "calculating truedl for #{tournaments.size} tournaments"
-
-    tournaments.each_with_index do |tournament_id, index|
-      calculate_for_tournament(tournament_id:, model_name:)
-      Rails.logger.info "Progress: #{index + 1}/#{tournaments.size}" if (index + 1) % 10 == 0
-    end
-  end
-
   attr_reader :tournament_id, :model
 
   def initialize(tournament_id, model_name)


### PR DESCRIPTION
A single job is difficult to retry and requires a lot of memory. Each actual job instead will only calculate truedl for a single tournament.