### PR TITLE
recreate materialized views concurrently

### DIFF
--- a/app/lib/materialized_views.rb
+++ b/app/lib/materialized_views.rb
@@ -40,7 +40,7 @@ class MaterializedViews
       as #{definition.query}
       with no data
     SQL
-    refresh_query = "refresh materialized view #{@model}.#{definition.name}"
+    refresh_query = "refresh materialized view concurrently #{@model}.#{definition.name}"
     index_queries = definition.index_columns.map do |column|
       index_name = "#{definition.name}_#{column}_idx"
       "create index if not exists #{index_name} on #{@model}.#{definition.name} (#{column})"


### PR DESCRIPTION
We were making other queries wait for the refresh query to finish. This query was taking longer and longer, and this led to very long queues of requests to player pages.

Running REFRESH MATERIALIZED VIEW with CONCURRENTLY means that we create a new version of the view as a separate entity, and lock the original view only for a brief time when we replace it with the new version.

https://www.postgresql.org/docs/15/sql-refreshmaterializedview.html