### PR TITLE
recreate materialized views concurrently

### DIFF
--- a/app/jobs/materialized_views_job.rb
+++ b/app/jobs/materialized_views_job.rb
@@ -3,7 +3,7 @@
 class MaterializedViewsJob < ApplicationJob
   queue_as :transform
 
-  ViewDefinition = Struct.new("ViewDefinition", :name, :query, :index_columns, keyword_init: true)
+  ViewDefinition = Data.define(:name, :query, :index_columns, :unique_index_columns)
 
   def perform(model)
     return if model.blank?
@@ -17,31 +17,60 @@ class MaterializedViewsJob < ApplicationJob
 
   private
 
+  def create_or_refresh_view(definition)
+    if view_exists?(definition)
+      refresh_view(definition)
+    else
+      create_view(definition)
+    end
+  end
+
   def definitions
     [player_ranking, team_ranking]
   end
 
-  def create_or_refresh_view(definition)
+  def view_exists?(definition)
+    query = <<~SQL
+      select 1
+      from pg_matviews
+      where matviewname = '#{definition.name}'
+        and schemaname = '#{@model}'
+    SQL
+    ActiveRecord::Base.connection.execute(query).any?
+  end
+
+  def create_view(definition)
     create_query = <<~SQL
       create materialized view if not exists #{@model}.#{definition.name}
+      with (fillfactor = 90)
       as #{definition.query}
-      with no data
     SQL
-    refresh_query = "refresh materialized view #{@model}.#{definition.name}"
+
+    unique_index_query = <<~SQL
+      create unique index if not exists #{definition.name}_unique_idx
+      on #{@model}.#{definition.name} (#{definition.unique_index_columns.join(", ")})
+    SQL
+
     index_queries = definition.index_columns.map do |column|
       index_name = "#{definition.name}_#{column}_idx"
       "create index if not exists #{index_name} on #{@model}.#{definition.name} (#{column})"
     end
 
     ActiveRecord::Base.connection.exec_query(create_query)
-    ActiveRecord::Base.connection.exec_query(refresh_query)
+    ActiveRecord::Base.connection.exec_query(unique_index_query)
     index_queries.each { |query| ActiveRecord::Base.connection.exec_query(query) }
+  end
+
+  def refresh_view(definition)
+    refresh_query = "refresh materialized view concurrently #{@model}.#{definition.name}"
+    ActiveRecord::Base.connection.exec_query(refresh_query)
   end
 
   def player_ranking
     ViewDefinition.new(
       name: "player_ranking",
       index_columns: %w[player_id release_id place],
+      unique_index_columns: %w[player_id release_id],
       query: <<~SQL
         select rank() over (partition by release_id order by rating desc) as place,
             player_id, rating, rating_change, release_id
@@ -54,6 +83,7 @@ class MaterializedViewsJob < ApplicationJob
     ViewDefinition.new(
       name: "team_ranking",
       index_columns: %w[team_id release_id place],
+      unique_index_columns: %w[team_id release_id],
       query: <<~SQL
         select rank() over (partition by release_id order by rating desc) as place,
             team_id, rating, rating_change, release_id, trb

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,18 +3,41 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "5cb3eefe998bc1686fb15aae1963a03b49d2bb1d8f4417028f31c50972e42db4",
+      "fingerprint": "941cc26d45719acdcb88134079936420d773d0b69454b2f52e38b8d626b86182",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/jobs/materialized_views_job.rb",
-      "line": 36,
+      "line": 60,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.exec_query(\"create materialized view if not exists #{@model}.#{definition.name}\\nas #{definition.query}\\nwith no data\\n\")",
+      "code": "ActiveRecord::Base.connection.exec_query(\"create unique index if not exists #{definition.name}_unique_idx\\non #{@model}.#{definition.name} (#{definition.unique_index_columns.join(\", \")})\\n\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "MaterializedViewsJob",
-        "method": "create_or_refresh_view"
+        "method": "create_view"
+      },
+      "user_input": "definition.name",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "model can only be a Model.name"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "b1086da9d532c1e2e7bed76d25626feca4d7003ecaba50596a17394b2c44c219",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/jobs/materialized_views_job.rb",
+      "line": 67,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.exec_query(\"refresh materialized view concurrently #{@model}.#{definition.name}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MaterializedViewsJob",
+        "method": "refresh_view"
       },
       "user_input": "@model",
       "confidence": "Medium",
@@ -26,20 +49,43 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "873b5c2c319025c31828f81c5422b728366e3934f6a935f724dc4ab83e730b80",
+      "fingerprint": "bd1a45bae54ea09445c9c12e67a8521ca0df4c016092f6384baf0976194a50e1",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/jobs/materialized_views_job.rb",
-      "line": 37,
+      "line": 59,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.exec_query(\"refresh materialized view #{@model}.#{definition.name}\")",
+      "code": "ActiveRecord::Base.connection.exec_query(\"create materialized view if not exists #{@model}.#{definition.name}\\nwith (fillfactor = 90)\\nas #{definition.query}\\n\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "MaterializedViewsJob",
-        "method": "create_or_refresh_view"
+        "method": "create_view"
       },
       "user_input": "@model",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "model can only be a Model.name"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "c48c554e69e59cdb3e8eba93ae73f3f301fdad166fc000dd240048bfd0249153",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/jobs/materialized_views_job.rb",
+      "line": 39,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"select 1\\nfrom pg_matviews\\nwhere matviewname = '#{definition.name}'\\n  and schemaname = '#{@model}'\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MaterializedViewsJob",
+        "method": "view_exists?"
+      },
+      "user_input": "definition.name",
       "confidence": "Medium",
       "cwe_id": [
         89

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,8 @@ VCR.configure do |config|
 end
 
 ModelIndexer.run
+ActiveRecord::Base.connection.execute("DROP MATERIALIZED VIEW IF EXISTS b.team_ranking")
+ActiveRecord::Base.connection.execute("DROP MATERIALIZED VIEW IF EXISTS b.player_ranking")
 MaterializedViewsJob.perform_now(InModel::DEFAULT_MODEL)
 
 ActiveRecord::Base.connection.execute("TRUNCATE b.release RESTART IDENTITY CASCADE")


### PR DESCRIPTION
We were making other queries wait for the refresh query to finish. This query was taking longer and longer, and this led to very long queues of requests to player pages.

Running REFRESH MATERIALIZED VIEW with CONCURRENTLY means that we create a new version of the view as a separate entity, and lock the original view only for a brief time when we replace it with the new version.

https://www.postgresql.org/docs/15/sql-refreshmaterializedview.html