### PR TITLE
use player_rating instead of player_ranking

### DIFF
--- a/app/jobs/materialized_views_job.rb
+++ b/app/jobs/materialized_views_job.rb
@@ -26,7 +26,7 @@ class MaterializedViewsJob < ApplicationJob
   end
 
   def definitions
-    [player_ranking, team_ranking]
+    [team_ranking]
   end
 
   def view_exists?(definition)
@@ -64,19 +64,6 @@ class MaterializedViewsJob < ApplicationJob
   def refresh_view(definition)
     refresh_query = "refresh materialized view concurrently #{@model}.#{definition.name}"
     ActiveRecord::Base.connection.exec_query(refresh_query)
-  end
-
-  def player_ranking
-    ViewDefinition.new(
-      name: "player_ranking",
-      index_columns: %w[player_id release_id place],
-      unique_index_columns: %w[player_id release_id],
-      query: <<~SQL
-        select rank() over (partition by release_id order by rating desc) as place,
-            player_id, rating, rating_change, release_id
-        from #{@model}.player_rating
-      SQL
-    )
   end
 
   def team_ranking

--- a/app/lib/player_queries.rb
+++ b/app/lib/player_queries.rb
@@ -57,9 +57,9 @@ module PlayerQueries
 
   def player_releases(player_id:)
     sql = <<~SQL
-      select rel.id, rel.date, ranking.place, ranking.rating, ranking.rating_change
+      select rel.id, rel.date, pr.place::integer, pr.rating, pr.rating_change
       from #{name}.release rel
-      left join #{name}.player_ranking ranking on ranking.player_id = $1 and ranking.release_id = rel.id
+      left join #{name}.player_rating pr on pr.player_id = $1 and pr.release_id = rel.id
       order by rel.date desc;
     SQL
 
@@ -92,7 +92,7 @@ module PlayerQueries
 
     sql = <<~SQL
       select tr.player_id, tr.rating
-      from #{name}.player_ranking tr
+      from #{name}.player_rating tr
       left join #{name}.release r on tr.release_id = r.id
       where r.date = $1 and tr.player_id IN (#{placeholders})
     SQL

--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -225,9 +225,11 @@ module ReleaseQueries
           left join ordered o2 on o1.row_number = o2.row_number + 1
       )
 
-      select r.*, prev.place as previous_place, r.place - prev.place as place_change
-      from #{name}.player_ranking r
-      left join #{name}.player_ranking prev
+      select r.release_id, r.player_id, r.rating, r.rating_change, r.place::integer, 
+          prev.place::integer as previous_place, 
+          r.place::integer - prev.place::integer as place_change
+      from #{name}.player_rating r
+      left join #{name}.player_rating prev
         on r.player_id = prev.player_id
             and prev.release_id = (select prev_release_id from releases where release_id = $1)
       where r.release_id = $1
@@ -251,12 +253,12 @@ module ReleaseQueries
           left join ordered o2 on o1.row_number = o2.row_number + 1
       )
 
-      select r.*,
-        prev.place as previous_place,
-        r.place - prev.place as place_change,
+      select r.release_id, r.player_id, r.rating, r.rating_change, r.place::integer,
+        prev.place::integer as previous_place,
+        (r.place::integer - prev.place::integer) as place_change,
         p.first_name || ' ' || p.last_name as name
-      from #{name}.player_ranking r
-      left join #{name}.player_ranking prev
+      from #{name}.player_rating r
+      left join #{name}.player_rating prev
         on r.player_id = prev.player_id
           and prev.release_id = (select prev_release_id from releases where release_id = $1)
       left join public.players p 

--- a/test/jobs/materialized_views_job_test.rb
+++ b/test/jobs/materialized_views_job_test.rb
@@ -28,7 +28,6 @@ class MaterializedViewsJobTest < ActiveSupport::TestCase
       )
     SQL
 
-    @connection.execute("DROP MATERIALIZED VIEW IF EXISTS #{@schema}.player_ranking")
     @connection.execute("DROP MATERIALIZED VIEW IF EXISTS #{@schema}.team_ranking")
   end
 
@@ -39,16 +38,9 @@ class MaterializedViewsJobTest < ActiveSupport::TestCase
   def test_perform_creates_materialized_views
     MaterializedViewsJob.perform_now(@schema)
 
-    assert view_exists?("player_ranking"), "player_ranking view was not created"
     assert view_exists?("team_ranking"), "team_ranking view was not created"
 
-    assert_columns_exist("player_ranking", %w[place player_id rating rating_change release_id])
     assert_columns_exist("team_ranking", %w[place team_id rating rating_change release_id trb])
-
-    %w[player_id release_id place].each do |column|
-      index_name = "player_ranking_#{column}_idx"
-      assert index_exists?("player_ranking", index_name), "Index #{index_name} should exist"
-    end
 
     %w[team_id release_id place].each do |column|
       index_name = "team_ranking_#{column}_idx"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,6 @@ end
 
 ModelIndexer.run
 ActiveRecord::Base.connection.execute("DROP MATERIALIZED VIEW IF EXISTS b.team_ranking")
-ActiveRecord::Base.connection.execute("DROP MATERIALIZED VIEW IF EXISTS b.player_ranking")
 MaterializedViewsJob.perform_now(InModel::DEFAULT_MODEL)
 
 ActiveRecord::Base.connection.execute("TRUNCATE b.release RESTART IDENTITY CASCADE")


### PR DESCRIPTION
We now add `place` during rating calculations, so we don’t need to maintain this materialized view (and can use player_rating instead of it in all queries).