### PR TITLE
don’t add text to queries with empty filters

### DIFF
--- a/app/controllers/player_releases_controller.rb
+++ b/app/controllers/player_releases_controller.rb
@@ -8,10 +8,8 @@ class PlayerReleasesController < ApplicationController
     @releases_in_dropdown = list_releases_for_dropdown
 
     @players = current_model.players_for_release(release_id: @release_id, from:, to:, first_name:, last_name:)
-    all_players_count = current_model.count_all_players_in_release(release_id: @release_id, first_name:, last_name:)
-    @paging = Paging.new(items_count: all_players_count, from:, to:)
-
     @filtered = first_name.present? || last_name.present?
+    @paging = Paging.new(items_count: all_players_count, from:, to:)
 
     @model_name = current_model.name
   end
@@ -34,6 +32,14 @@ class PlayerReleasesController < ApplicationController
 
   def last_name
     @last_name ||= clean_params[:last_name]&.gsub("*", "")
+  end
+
+  def all_players_count
+    if @filtered
+      current_model.count_all_players_in_release_with_filters(release_id: @release_id, first_name:, last_name:)
+    else
+      current_model.count_all_players_in_release(release_id: @release_id)
+    end
   end
 
   def list_releases_for_dropdown

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -9,10 +9,8 @@ class ReleasesController < ApplicationController
     teams = current_model.teams_for_release(release_id: id, from:, to:, team_name: team, city:)
     @release = ReleasePresenter.new(id:, teams:)
 
-    all_teams_count = current_model.count_all_teams_in_release(release_id: id, team_name: team, city:)
-    @paging = Paging.new(items_count: all_teams_count, from:, to:)
-
     @filtered = city.present? || team.present?
+    @paging = Paging.new(items_count: all_teams_count, from:, to:)
 
     @releases_in_dropdown = list_releases_for_dropdown
     @model_name = current_model.name
@@ -43,6 +41,14 @@ class ReleasesController < ApplicationController
       current_model&.latest_release_id
     else
       clean_params[:release_id].to_i
+    end
+  end
+
+  def all_teams_count
+    if @filtered
+      current_model.count_all_teams_in_release_with_filters(release_id: id, team_name: team, city:)
+    else
+      current_model.count_all_teams_in_release(release_id: id)
     end
   end
 

--- a/app/lib/release_queries.rb
+++ b/app/lib/release_queries.rb
@@ -158,7 +158,19 @@ module ReleaseQueries
     exec_query_for_single_value(query: sql)
   end
 
-  def count_all_teams_in_release(release_id:, team_name: nil, city: nil)
+  def count_all_teams_in_release(release_id:)
+    sql = <<~SQL
+      select count(*)
+      from #{name}.team_rating tr
+      left join public.teams t on t.id = tr.team_id
+      left join public.towns town on town.id = t.town_id
+      where tr.release_id = $1
+    SQL
+
+    exec_query_for_single_value(query: sql, params: [release_id], default_value: 0, cache: true)
+  end
+
+  def count_all_teams_in_release_with_filters(release_id:, team_name: nil, city: nil)
     sql = <<~SQL
       select count(*)
       from #{name}.team_rating tr
@@ -272,7 +284,18 @@ module ReleaseQueries
     exec_query_for_hash_array(query: sql, params: [release_id, limit, offset])
   end
 
-  def count_all_players_in_release(release_id:, first_name: nil, last_name: nil)
+  def count_all_players_in_release(release_id:)
+    sql = <<~SQL
+      select count(*)
+      from #{name}.player_rating pr
+      left join public.players p on p.id = pr.player_id
+      where release_id = $1
+    SQL
+
+    exec_query_for_single_value(query: sql, params: [release_id], default_value: 0, cache: true)
+  end
+
+  def count_all_players_in_release_with_filters(release_id:, first_name:, last_name:)
     sql = <<~SQL
       select count(*)
       from #{name}.player_rating pr


### PR DESCRIPTION
Queries for '%%' are expensive, so when there is no player name or team city in the filter, we should run a simpler query.