### PR TITLE
migrate players jobs

### DIFF
--- a/app/jobs/players_job.rb
+++ b/app/jobs/players_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class PlayersJob < ApplicationJob
+  queue_as :default
+  limits_concurrency to: 1, key: :chgk_info_api
+
+  attr_reader :api_client
+
+  def perform
+    @api_client = ChgkInfo::APIClient.new
+
+    page_number = 1
+    players = fetch_page(page_number)
+
+    while players.size > 0
+      player_rows = players.map do
+        {
+          id: player["id"],
+          first_name: player["name"],
+          patronymic: player["patronymic"],
+          last_name: player["surname"]
+        }
+      end
+
+      ActiveRecord::Base.transaction do
+        Player.upsert_all(player_rows)
+      end
+
+      page_number += 1
+      players = fetch_page(page_number)
+    end
+  end
+
+  def fetch_page(page)
+    @api_client.players(page:)
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -39,6 +39,11 @@ production:
     class: TeamsJob
     schedule: 30 16 * * *
 
+  # Names for players
+  players:
+    class: PlayersJob
+    schedule: every day at 10:30
+
   clear_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches"
     schedule: every day at 16:00

--- a/db/migrate/20250502100000_add_unique_index_to_players.rb
+++ b/db/migrate/20250502100000_add_unique_index_to_players.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToPlayers < ActiveRecord::Migration[8.0]
+  def change
+    add_index :players, :id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_21_105044) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_02_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +41,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_21_105044) do
     t.text "patronymic"
     t.text "last_name"
     t.datetime "updated_at", precision: nil
+    t.index ["id"], name: "index_players_on_id", unique: true
     t.index ["id"], name: "players_id_index"
   end
 


### PR DESCRIPTION
Previously defined in https://github.com/chgk-gg/rating-importer/blob/3ffcfe79b110256ccf4ebea448a16470a9791fa6/fetchers/players.rb and https://github.com/chgk-gg/rating-importer/blob/3ffcfe79b110256ccf4ebea448a16470a9791fa6/importers/players_importer.rb

We need a unique index for upsert_all to work.