### PR TITLE
add two fields to players table

### DIFF
--- a/app/jobs/players_job.rb
+++ b/app/jobs/players_job.rb
@@ -18,7 +18,9 @@ class PlayersJob < ApplicationJob
           id: player["id"],
           first_name: player["name"],
           patronymic: player["patronymic"],
-          last_name: player["surname"]
+          last_name: player["surname"],
+          date_died: player["dateDied"],
+          got_questions_tag: player["gotQuestionsTag"]
         }
       end
 

--- a/db/migrate/20250502103022_add_two_fields_to_players.rb
+++ b/db/migrate/20250502103022_add_two_fields_to_players.rb
@@ -1,0 +1,6 @@
+class AddTwoFieldsToPlayers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :players, :date_died, :date
+    add_column :players, :got_questions_tag, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_02_100000) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_02_103022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +41,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_02_100000) do
     t.text "patronymic"
     t.text "last_name"
     t.datetime "updated_at", precision: nil
+    t.date "date_died"
+    t.integer "got_questions_tag"
     t.index ["id"], name: "index_players_on_id", unique: true
     t.index ["id"], name: "players_id_index"
   end


### PR DESCRIPTION
We want to track death dates to remove dead players from calculations.
We now import editors for tournaments, and when showing them on a tournament’s page it would nice to link to their questions.