### PR TITLE
move all jobs into meaningfully-named queues

### DIFF
--- a/app/jobs/all_rating_tournament_results_job.rb
+++ b/app/jobs/all_rating_tournament_results_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AllRatingTournamentResultsJob < ApplicationJob
-  queue_as :default
+  queue_as :wrappers
 
   def perform
     single_tournament_jobs = tournaments

--- a/app/jobs/players_job.rb
+++ b/app/jobs/players_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PlayersJob < ApplicationJob
-  queue_as :default
+  queue_as :chgk_info_import
   limits_concurrency to: 1, key: :chgk_info_api
 
   attr_reader :api_client

--- a/app/jobs/recent_tournament_results_job.rb
+++ b/app/jobs/recent_tournament_results_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RecentTournamentResultsJob < ApplicationJob
-  queue_as :default
+  queue_as :wrappers
 
   def perform(days)
     single_tournament_jobs = recent_tournaments(days)

--- a/app/jobs/single_tournament_results_job.rb
+++ b/app/jobs/single_tournament_results_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SingleTournamentResultsJob < ApplicationJob
-  queue_as :default
+  queue_as :chgk_info_import
   limits_concurrency to: 1, key: :chgk_info_api
 
   attr_reader :tournament_id, :api_client

--- a/app/jobs/teams_job.rb
+++ b/app/jobs/teams_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TeamsJob < ApplicationJob
-  queue_as :default
+  queue_as :chgk_info_import
   limits_concurrency to: 1, key: :chgk_info_api
 
   attr_reader :api_client

--- a/app/jobs/truedl_for_all_tournaments_job.rb
+++ b/app/jobs/truedl_for_all_tournaments_job.rb
@@ -1,7 +1,7 @@
 require_relative "../lib/truedl_calculator"
 
 class TrueDLForAllTournamentsJob < ApplicationJob
-  queue_as :default
+  queue_as :wrappers
 
   def perform(model_name)
     model = Model.find_by(name: model_name)

--- a/app/jobs/truedl_for_tournament_job.rb
+++ b/app/jobs/truedl_for_tournament_job.rb
@@ -1,7 +1,7 @@
 require_relative "../lib/truedl_calculator"
 
 class TrueDLForTournamentJob < ApplicationJob
-  queue_as :default
+  queue_as :transform
 
   def perform(model_name, tournament_id)
     TrueDLCalculator.calculate_for_tournament(tournament_id:, model_name:)


### PR DESCRIPTION
transform is for internal data processing, chgk_info_import is for imports from api.chgk.info, wrappers start a bunch of sub-jobs, backup is for backups.