### PR TITLE
cache models during startup

### DIFF
--- a/app/controllers/concerns/in_model.rb
+++ b/app/controllers/concerns/in_model.rb
@@ -4,8 +4,17 @@ module InModel
   DEFAULT_MODEL = "b"
   MISSING_MODEL_ERROR = "Модели с таким именем нет"
 
+  def self.models_cache
+    @models_cache ||= reload_model_cache!
+  end
+
+  def self.reload_model_cache!
+    @models_cache = Model.all.index_by(&:name)
+  end
+
   def current_model
-    Model.find_by(name: params[:model] || DEFAULT_MODEL)
+    model_name = params[:model] || DEFAULT_MODEL
+    InModel.models_cache[model_name]
   end
 
   def show_missing_model_error(_exception)

--- a/app/lib/model_indexer.rb
+++ b/app/lib/model_indexer.rb
@@ -12,6 +12,7 @@ class ModelIndexer
     end
 
     Model.upsert_all(models, unique_by: :name)
+    InModel.reload_model_cache!
   end
 
   def self.schemas

--- a/test/system/team_release_page_test.rb
+++ b/test/system/team_release_page_test.rb
@@ -49,4 +49,12 @@ class TeamReleasePageTest < ActionDispatch::IntegrationTest
 
     assert_selector "table tbody tr", count: 4
   end
+
+  test "does not make database queries for models" do
+    count, matching_queries = count_queries("FROM \"models\"") do
+      visit "/"
+    end
+
+    assert_equal 0, count, "Found #{count} model queries: #{matching_queries.join("\n")}"
+  end
 end


### PR DESCRIPTION
Models basically never change, so there is no need to go the database more than once.

Models can be changed by reindexing, so we explicitly reload this cache in ModelIndexer now.

Team release page might not sound like an ideal place for this test, but it’s our home page, so this means something like “when we load a page, we don’t query the models table, and it’s enough to test this for a default page”.