### PR TITLE
set up replica database for web requests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 
 /node_modules
 /vendor/cache
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Setup and Development
+- `bundle install` - Install Ruby dependencies
+- `bun install` - Install JavaScript dependencies  
+- `bin/dev` - Start development server (runs Rails server, JS build watcher, CSS build watcher)
+- `bin/rails server` - Start Rails server only
+- `bun run build` - Build JavaScript assets
+- `bun run build:css` - Build CSS assets
+
+### Testing and Quality
+- `bundle exec minitest` - Run all tests
+- `rails test test/system/player_page_test.rb` - Run a specific test file
+- `bundle exec rubocop` - Run linting
+- `bundle exec standard` - Run Standard Ruby style checker
+- `bundle exec brakeman` - Run security analysis
+
+### Database Development
+This project requires a PostgreSQL database with specific schema from the [rating-db](https://github.com/chgk-gg/rating-db) repository. Use that repository to download a recent backup and run it with Docker for development.
+
+## Architecture Overview
+
+### Multi-Model Rating System
+This Rails application displays team and player rankings for multiple rating models (e.g., model "b"). Each model uses separate database schemas/tables, requiring raw SQL queries for model-specific data while using standard ActiveRecord for shared tables like BaseRoster.
+
+### Key Concepts
+- **Models**: Different ranking calculation models stored in separate database schemas
+- **Current Model**: Determined by URL parameter (`:model`) or defaults to "b" (InModel::DEFAULT_MODEL)
+- **Model Switching**: Routes use `:model` parameter to switch between different rating schemas
+- **Raw SQL Usage**: Model-specific queries use raw SQL due to dynamic table names
+
+### Data Flow
+1. Data imported from rating.chgk.info via [rating-importer](https://github.com/chgk-gg/rating-importer)
+2. Rankings calculated in [rating-b](https://github.com/chgk-gg/rating-b) project
+3. This app displays the calculated rankings with model switching capability
+
+### Frontend Stack
+- Rails with Turbo and Stimulus.js
+- Tailwind CSS for styling
+- Bun for JavaScript bundling
+- View Components for reusable UI elements
+
+### Background Jobs
+- Uses SolidQueue for job processing
+- Notable jobs: TrueDL difficulty calculation, tournament results processing
+- Mission Control Jobs UI available at `/jobs`
+
+### API Structure
+- REST API under `/api/v1/` namespace
+- All endpoints require `:model` parameter
+- Provides data for teams, players, tournaments, and releases

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,9 @@ class ApplicationController < ActionController::Base
     rescue_from ActiveRecord::StatementInvalid, with: :show_model_errors
   end
 
+  # Use replica database for all web requests since controllers don't write data directly
+  around_action :use_replica_database
+
   before_action :validate_model_name
 
   protected
@@ -19,6 +22,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def use_replica_database(&block)
+    ActiveRecord::Base.connected_to(role: :reading, &block)
+  end
 
   def validate_model_name
     return if params[:model].blank? || params[:model] =~ /\A[a-zA-Z_]+\z/

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,11 @@
 class ApplicationJob < ActiveJob::Base
+  # Ensure jobs always use the primary database for writes
+  around_perform do |_job, block|
+    ActiveRecord::Base.connected_to(role: :writing, &block)
+  end
+
+  # Ensure job scheduling (perform_later) uses primary database for Solid Queue
+  around_enqueue do |_job, block|
+    ActiveRecord::Base.connected_to(role: :writing, &block)
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,6 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to database: {writing: :primary, reading: :replica}
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,5 @@
 default: &default
   adapter: postgresql
-  url: <%= ENV.fetch('DATABASE_URL', "postgres://postgres:password@localhost:5432/postgres") %>
   pool: 5
   variables:
     statement_timeout: <%= ENV.fetch("DATABASE_STATEMENT_TIMEOUT", 5000)%>
@@ -8,16 +7,41 @@ default: &default
     lock_timeout: <%= ENV.fetch("DATABASE_LOCK_TIMEOUT", 5000)%>
 
 production:
-  <<: *default
-  connect_timeout: 5
-  checkout_timeout: 5
+  primary:
+    <<: *default
+    url: <%= ENV.fetch('DATABASE_URL', "postgres://postgres:password@localhost:5432/postgres") %>
+    connect_timeout: 5
+    checkout_timeout: 5
+  replica:
+    <<: *default
+    url: <%= ENV.fetch('REPLICA_DATABASE_URL', ENV.fetch('DATABASE_URL', "postgres://postgres:password@localhost:5432/postgres")) %>
+    connect_timeout: 5
+    checkout_timeout: 5
+    replica: true
 
 staging:
-  <<: *default
+  primary:
+    <<: *default
+    url: <%= ENV.fetch('DATABASE_URL', "postgres://postgres:password@localhost:5432/postgres") %>
+  replica:
+    <<: *default
+    url: <%= ENV.fetch('REPLICA_DATABASE_URL', ENV.fetch('DATABASE_URL', "postgres://postgres:password@localhost:5432/postgres")) %>
+    replica: true
 
 test:
-  <<: *default
-  url: <%= ENV['DATABASE_URL'] || 'postgres://postgres:postgres@localhost:5432/test_db' %>
+  primary:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] || 'postgres://postgres:postgres@localhost:5432/test_db' %>
+  replica:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] || 'postgres://postgres:postgres@localhost:5432/test_db' %>
+    replica: true
 
 development:
-  <<: *default
+  primary:
+    <<: *default
+    url: <%= ENV.fetch('DATABASE_URL', "postgres://postgres:password@localhost:5432/postgres") %>
+  replica:
+    <<: *default
+    url: <%= ENV.fetch('REPLICA_DATABASE_URL', ENV.fetch('DATABASE_URL', "postgres://postgres:password@localhost:5432/postgres")) %>
+    replica: true


### PR DESCRIPTION
All web requests are read-only, so we can send them to the replica database. An exception is those requests which schedule a job, so we wrap these perform_later calls with connected_to to use the main database. Jobs will continue using the main database.