### PR TITLE
stop adding unnecessary name filters to release queries

### DIFF
--- a/app/controllers/player_releases_controller.rb
+++ b/app/controllers/player_releases_controller.rb
@@ -35,11 +35,7 @@ class PlayerReleasesController < ApplicationController
   end
 
   def all_players_count
-    if @filtered
-      current_model.count_all_players_in_release_with_filters(release_id: @release_id, first_name:, last_name:)
-    else
-      current_model.count_all_players_in_release(release_id: @release_id)
-    end
+    current_model.count_all_players_in_release(release_id: @release_id, first_name:, last_name:)
   end
 
   def list_releases_for_dropdown

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -45,11 +45,7 @@ class ReleasesController < ApplicationController
   end
 
   def all_teams_count
-    if @filtered
-      current_model.count_all_teams_in_release_with_filters(release_id: id, team_name: team, city:)
-    else
-      current_model.count_all_teams_in_release(release_id: id)
-    end
+    current_model.count_all_teams_in_release(release_id: id, team_name: team, city:)
   end
 
   def list_releases_for_dropdown


### PR DESCRIPTION
Several release-fetching queries were unnecessarily filtering by empty names and cities, which made them slower. I’ve reworked related `count_all_*` methods to have only one method and not make controllers pick a correct one.