### PR TITLE
post lists of tournaments that break rules to telegram 

### DIFF
--- a/app/jobs/rules_job.rb
+++ b/app/jobs/rules_job.rb
@@ -1,0 +1,5 @@
+class RulesJob < ApplicationJob
+  def perform
+    TelegramClient.send_message(Rails.application.config.test_telegram_channel, Rules::AppealJuryRule.message)
+  end
+end

--- a/app/lib/rules/abstract_rule.rb
+++ b/app/lib/rules/abstract_rule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Rules
+  class AbstractRule
+    def self.description
+      raise NotImplementedError, "You must implement the description method in a subclass"
+    end
+
+    def self.offenders
+      raise NotImplementedError, "You must implement the offenders method in a subclass"
+    end
+
+    def self.message
+      "#{description}:\n#{offenders}"
+    end
+  end
+end

--- a/app/lib/rules/appeal_jury_rule.rb
+++ b/app/lib/rules/appeal_jury_rule.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Rules
+  class AppealJuryRule < AbstractRule
+    def self.description
+      "Турниры, в которых меньше трёх человек в апелляционном жюри"
+    end
+
+    def self.offenders
+      tournaments = Tournament.left_joins(:tournament_appeal_jury)
+        .where(start_datetime: (Time.zone.today..(Time.zone.today + 3.days)))
+        .where(maii_rating: true)
+        .group("tournaments.id, tournaments.title")
+        .having("count(tournament_appeal_jury.id) < 3")
+        .select("tournaments.id, tournaments.title")
+
+      tournaments.map do |tournament|
+        "<a href='https://rating.chgk.info/tournament/#{tournament.id}'>#{tournament.title}</a>"
+      end.join("\n")
+    end
+  end
+end

--- a/app/lib/telegram_client.rb
+++ b/app/lib/telegram_client.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "httparty"
+
+class TelegramClient
+  include HTTParty
+
+  base_uri "https://api.telegram.org"
+
+  class << self
+    def send_message(channel_name, message_text)
+      return false if token.blank?
+
+      post("/bot#{token}/sendMessage", {
+        body: {
+          chat_id: channel_name,
+          text: message_text,
+          parse_mode: "HTML"
+        }
+      })
+    rescue => e
+      Rails.logger.error "TelegramClient error: #{e.message}"
+      false
+    end
+
+    private
+
+    def token
+      Rails.application.config.telegram_token
+    end
+  end
+end

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -4,6 +4,10 @@ class Tournament < ApplicationRecord
 
   has_many :tournament_results, dependent: :destroy
   has_many :tournament_rosters, dependent: :destroy
+  has_many :tournament_appeal_jury, dependent: :destroy
+  has_many :tournament_game_jury, dependent: :destroy
+  has_many :tournament_organizers, dependent: :destroy
+  has_many :tournament_editors, dependent: :destroy
 
   def self.pre_maii_tournaments_for_team(team_id)
     Tournament.joins(:tournament_results)

--- a/config/initializers/telegram_client.rb
+++ b/config/initializers/telegram_client.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.telegram_token = ENV["TELEGRAM_TOKEN"]
+  config.telegram_channel = "@rating_chgkgg_technical"
+  config.test_telegram_channel = "@rating_chgkgg_technical"
+end


### PR DESCRIPTION
We start with a single rule that checks that tournaments have 3 or more appeal jury members. Future rules will inherit from `AbstractRule`.

https://github.com/chgk-gg/rating-ui/issues/404