### PR TITLE
stop recalculating current season for team page

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -19,6 +19,6 @@ class TeamsController < ApplicationController
     @old_tournaments = Tournament.pre_maii_tournaments_for_team(team_id).map(&:attributes)
     @old_tournaments.each { |t| t["players"] = @all_players[t["id"]] }
 
-    @base_roster = @team.current_base_roster
+    @base_roster = @team.base_roster_for_season(@current_season.id)
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -18,12 +18,8 @@ class Team < ApplicationRecord
       .group_by(&:tournament_id)
   end
 
-  def current_base_roster
-    today = Time.zone.today
-    base_rosters.joins("left join seasons on base_rosters.season_id = seasons.id")
-      .joins("left join players on players.id = base_rosters.player_id")
-      .where("? between seasons.start and seasons.end", today)
-      .where("start_date <= ? and (end_date > ? or end_date is null)", today, today)
+  def base_roster_for_season(season_id)
+    base_rosters.where(season_id:).joins("left join players on players.id = base_rosters.player_id")
       .order("players.last_name")
       .select("players.id as player_id", players: [:first_name, :last_name])
   end

--- a/test/system/team_page_test.rb
+++ b/test/system/team_page_test.rb
@@ -23,14 +23,11 @@ class TeamPageTest < ActionDispatch::IntegrationTest
   end
 
   test "team page has its base roster" do
+    Season.stubs(:current_season).returns(seasons(:season_2024))
+
     visit team_url(@team_id)
 
-    season_title = if Time.zone.today.month >= 9
-      "#{Time.zone.today.year}/#{(Time.zone.today.year + 1).to_s.last(2)}"
-    else
-      "#{Time.zone.today.year - 1}/#{Time.zone.today.year.to_s.last(2)}"
-    end
-    assert_text "Базовый состав на сезон #{season_title}"
+    assert_text "Базовый состав на сезон 2024/25"
 
     players = find("div.bg-gray-200 > div:nth-child(1)").all("p a")
     assert_equal ["Carlos Garcia", "Aisha Khan", "Hiroshi Tanaka"], players.map(&:text)


### PR DESCRIPTION
To show base roster of a team on its page, we calculate what season is current twice (and in two different ways). `Team#current_base_roster` was used in that controller, and we pass `season_id` instead.

Also, fixes the season that we use to test this page.